### PR TITLE
Memory leak issues, Solving Issue #9

### DIFF
--- a/lib/DB/MySQL/Native.pm6
+++ b/lib/DB/MySQL/Native.pm6
@@ -317,7 +317,10 @@ class MYSQL_STMT is repr('CPointer')
         is native(LIBMYSQL) is symbol('mysql_stmt_execute') {}
 
     method store-result(--> MYSQL_RES)
-        is native(LIBMYSQL) is symbol('mysql_store_result') {}
+        is native(LIBMYSQL) is symbol('mysql_stmt_store_result') {}
+
+    method free-result(--> int32)
+        is native(LIBMYSQL) is symbol('mysql_stmt_free_result') {}
 
     method affected-rows(--> uint64)
         is native(LIBMYSQL) is symbol('mysql_stmt_affected_rows') {}

--- a/lib/DB/MySQL/Result.pm6
+++ b/lib/DB/MySQL/Result.pm6
@@ -43,7 +43,6 @@ class DB::MySQL::StatementResult does DB::MySQL::Result
 
     method free()
     {
-        while $.row {}                           # Exhaust unread results
         .free with $!result-bind;
         .free with $!result;
         $!result-bind = Nil;

--- a/lib/DB/MySQL/Statement.pm6
+++ b/lib/DB/MySQL/Statement.pm6
@@ -21,11 +21,12 @@ class DB::MySQL::Statement does DB::Statement
     {
         .free with $!params;
         $!params = Nil;
+        .free-result with $!stmt;
         .close with $!stmt;
         $!stmt = Nil;
     }
 
-    method execute(**@args, Bool :$finish, Bool :$store = True)
+    method execute(**@args, Bool :$finish, Bool :$store = True) # $store not used leave for backwards compatibility
     {
         die DB::MySQL::Error.new(message => 'Wrong number of params')
             unless @args.elems == $!param-count;
@@ -36,7 +37,7 @@ class DB::MySQL::Statement does DB::Statement
             $!stmt.check($!stmt.bind-param($!params[0]))
         }
 
-        $!stmt.check if $!stmt.execute || ($store && $!stmt.store-result);
+        $!stmt.check if $!stmt.execute;
 
         if my $result = $!stmt.result-metadata
         {


### PR DESCRIPTION
mysql_stmt_store_result will not be used with prepared statements.

Correction of store-result native call to use the correct method.

Added free method to ensure that resources are released properly after use.


https://github.com/CurtTilmes/perl6-dbmysql/issues/9
Segmentation fault on releasing resources with finish()  #9
